### PR TITLE
Store preferences to its default path

### DIFF
--- a/lib/prefs.js
+++ b/lib/prefs.js
@@ -43,7 +43,7 @@ function init()
       defineProperty(pref, false, getter, setter);
     }
   };
-  Services.scriptloader.loadSubScript(addonRoot + "defaults/prefs.js", scope);
+  Services.scriptloader.loadSubScript(addonRoot + "defaults/preferences/prefs.js", scope);
 
   // Add preference change observer
   try

--- a/packagerGecko.py
+++ b/packagerGecko.py
@@ -212,7 +212,7 @@ def addMissingFiles(params, files):
         templateData['hasChromeRequires'] = True
     if name.startswith('lib/') and re.search(r'\bXMLHttpRequest\b', content):
       templateData['hasXMLHttpRequest'] = True
-    if name == 'defaults/prefs.js':
+    if name == 'defaults/preferences/prefs.js':
       if re.search(r'\.currentVersion"', content):
         templateData['hasVersionPref'] = True
     if not '/' in name or name.startswith('lib/'):


### PR DESCRIPTION
Adapt build tools to the default preferences path, as requested in https://github.com/adblockplus/adblockplus/pull/4

Bug-Debian: https://bugs.debian.org/684390
Bug: https://adblockplus.org/forum/viewtopic.php?f=11&t=16529
