### PR TITLE
Issue2700 - ensure_dependencies does not work with python 2.6

### DIFF
--- a/ensure_dependencies.py
+++ b/ensure_dependencies.py
@@ -188,7 +188,7 @@ def read_deps(repodir):
 
 def safe_join(path, subpath):
   # This has been inspired by Flask's safe_join() function
-  forbidden = {os.sep, os.altsep} - {posixpath.sep, None}
+  forbidden = set([os.sep, os.altsep]) - set([posixpath.sep, None])
   if any(sep in subpath for sep in forbidden):
     raise Exception("Illegal directory separator in dependency path %s" % subpath)
 

--- a/ensure_dependencies.py
+++ b/ensure_dependencies.py
@@ -16,7 +16,10 @@ import subprocess
 import urlparse
 import argparse
 
-from collections import OrderedDict
+try:
+  from collections import OrderedDict
+except ImportError:
+  from ordereddict import OrderedDict
 from ConfigParser import RawConfigParser
 
 USAGE = """
@@ -98,7 +101,8 @@ class Git():
 
   def get_revision_id(self, repo, rev="HEAD"):
     command = ["git", "rev-parse", "--revs-only", rev + '^{commit}']
-    return subprocess.check_output(command, cwd=repo).strip()
+    result = subprocess.Popen(command,  stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=repo).communicate()[0]
+    return result.strip()
 
   def pull(self, repo):
     # Fetch tracked branches, new tags and the list of available remote branches


### PR DESCRIPTION
Issue2700 - ensure_dependencies does not work with python 2.6